### PR TITLE
Add crypto stablecoin payment component for checkout

### DIFF
--- a/src/CoachFitAI.Web/Pages/Checkout.razor
+++ b/src/CoachFitAI.Web/Pages/Checkout.razor
@@ -1,7 +1,6 @@
 @page "/checkout"
 @using CoachFitAI.Web.Services
 @inject AppState State
-@inject IPaymentService Payments
 @inject NavigationManager Nav
 
 <div class="container mt-5">
@@ -17,7 +16,9 @@
       else
       {
         <p class="fs-5">Plan price: <b>$7</b></p>
-        <button class="btn btn-primary px-4 mt-3" @onclick="Pay">Pay (mock)</button>
+        <div class="mt-4 text-start">
+          <CryptoStablecoinPayment AmountUsd="7m" OnPaymentCompleted="HandlePaymentCompleted" />
+        </div>
       }
 
     </div>
@@ -25,11 +26,8 @@
 </div>
 
 @code {
-  async Task Pay()
+  private void HandlePaymentCompleted()
   {
-    var order = await Payments.StartCheckoutAsync(7m);
-    State.SetOrder(order);
-    var ok = await Payments.ConfirmPaymentAsync(order.Id);
-    if (ok) Nav.NavigateTo("thank-you");
+    Nav.NavigateTo("thank-you");
   }
 }

--- a/src/CoachFitAI.Web/Pages/Shared/Components/CryptoStablecoinPayment.razor
+++ b/src/CoachFitAI.Web/Pages/Shared/Components/CryptoStablecoinPayment.razor
@@ -1,92 +1,94 @@
 @using System.Globalization
 @using System.Linq
+@using Microsoft.JSInterop
 @inject IPaymentService Payments
 @inject AppState State
+@inject IJSRuntime JS
 
-<div class="card shadow-sm crypto-stablecoin border-0">
-  <div class="card-body">
-    <h5 class="card-title">Pay with USDT or USDC</h5>
-    <p class="text-muted small mb-4">
+<div class="cf-card cf-payment-card">
+  <div class="cf-payment-header">
+    <h5 class="cf-payment-title">Pay with USDT or USDC</h5>
+    <p class="cf-payment-subtitle">
       Send the exact amount to the wallet address below using one of the supported networks.
       Once the transfer is complete, confirm to finalize your order.
     </p>
+  </div>
 
-    @if (_isLoading)
-    {
-      <div class="text-center py-4">
-        <div class="spinner-border text-primary" role="status">
-          <span class="visually-hidden">Loading...</span>
-        </div>
-      </div>
-    }
-    else if (!string.IsNullOrEmpty(_errorMessage))
-    {
-      <div class="alert alert-danger" role="alert">
-        @_errorMessage
-      </div>
-      <button class="btn btn-outline-primary w-100" @onclick="ReloadOrder">Retry</button>
-    }
-    else if (_isCompleted)
-    {
-      <div class="alert alert-success" role="alert">
-        Payment confirmed! You will be redirected shortly.
-      </div>
-    }
-    else if (_order is not null)
-    {
-      <div class="mb-3">
-        <label class="form-label">Choose a stablecoin</label>
-        <div class="btn-group w-100" role="group">
-          @foreach (var asset in _options.Keys)
-          {
-            <button type="button"
-                    class="btn btn-outline-primary @((asset == _selectedAsset ? "active" : string.Empty))"
-                    @onclick="() => SelectAsset(asset)">
-              @asset
-            </button>
-          }
-        </div>
-      </div>
-
-      <div class="mb-3">
-        <label class="form-label">Select network</label>
-        <select class="form-select" @bind="_selectedNetwork">
-          @foreach (var option in _options[_selectedAsset])
-          {
-            <option value="@option.Network">@option.Network</option>
-          }
-        </select>
-        <div class="form-text">Only send @AmountUsd.ToString("0.00", CultureInfo.InvariantCulture) @_selectedAsset on this network.</div>
-      </div>
-
-      <div class="mb-3">
-        <label class="form-label">Amount</label>
-        <div class="fs-5 fw-semibold">
-          @AmountUsd.ToString("0.00", CultureInfo.InvariantCulture) @_selectedAsset
-        </div>
-        <div class="form-text">Stablecoins track the US Dollar 1:1, so @AmountUsd.ToString("0.00", CultureInfo.InvariantCulture) USD = @AmountUsd.ToString("0.00", CultureInfo.InvariantCulture) @_selectedAsset.</div>
-      </div>
-
-      <div class="mb-3">
-        <label class="form-label">Wallet address</label>
-        <div class="border rounded px-3 py-2 bg-light user-select-all">
-          @SelectedOption.Address
-        </div>
-        @if (!string.IsNullOrWhiteSpace(SelectedOption.Note))
+  @if (_isLoading)
+  {
+    <div class="cf-payment-loading" role="status" aria-live="polite">
+      <div class="cf-spinner" aria-hidden="true"></div>
+      <span>Preparing payment...</span>
+    </div>
+  }
+  else if (!string.IsNullOrEmpty(_errorMessage))
+  {
+    <div class="cf-alert cf-alert-error" role="alert">
+      @_errorMessage
+    </div>
+    <button class="cf-btn cf-btn-primary w-100" @onclick="ReloadOrder">Retry</button>
+  }
+  else if (_isCompleted)
+  {
+    <div class="cf-alert cf-alert-success" role="status">
+      Payment confirmed! You will be redirected shortly.
+    </div>
+  }
+  else if (_order is not null)
+  {
+    <div class="cf-field">
+      <label>Choose a stablecoin</label>
+      <div class="cf-pill-group">
+        @foreach (var asset in _options.Keys)
         {
-          <div class="form-text">@SelectedOption.Note</div>
+          <button type="button"
+                  class="cf-pill @((asset == _selectedAsset ? "active" : string.Empty))"
+                  @onclick="() => SelectAsset(asset)">
+            @asset
+          </button>
         }
       </div>
+    </div>
 
-      <button class="btn btn-success w-100" @onclick="ConfirmPayment" disabled="@_isConfirming">
-        @_confirmButtonText
-      </button>
-      @if (!string.IsNullOrEmpty(_statusMessage))
+    <div class="cf-field">
+      <label>Select network</label>
+      <select @bind="_selectedNetwork">
+        @foreach (var option in _options[_selectedAsset])
+        {
+          <option value="@option.Network">@option.Network</option>
+        }
+      </select>
+      <span class="cf-help">Only send @AmountUsd.ToString("0.00", CultureInfo.InvariantCulture) @_selectedAsset on this network.</span>
+    </div>
+
+    <div class="cf-field">
+      <label>Amount</label>
+      <div class="cf-amount-display">
+        <span class="cf-amount-value">@AmountUsd.ToString("0.00", CultureInfo.InvariantCulture)</span>
+        <span class="cf-amount-asset">@_selectedAsset</span>
+      </div>
+      <span class="cf-help">Stablecoins track the US Dollar 1:1, so @AmountUsd.ToString("0.00", CultureInfo.InvariantCulture) USD = @AmountUsd.ToString("0.00", CultureInfo.InvariantCulture) @_selectedAsset.</span>
+    </div>
+
+    <div class="cf-field">
+      <label>Wallet address</label>
+      <div class="cf-wallet" title="Click to copy" @onclick="() => CopyToClipboard(SelectedOption.Address)">
+        @SelectedOption.Address
+      </div>
+      @if (!string.IsNullOrWhiteSpace(SelectedOption.Note))
       {
-        <div class="form-text text-muted text-center mt-2">@_statusMessage</div>
+        <span class="cf-help">@SelectedOption.Note</span>
       }
+    </div>
+
+    <button class="cf-btn cf-btn-primary w-100" @onclick="ConfirmPayment" disabled="@_isConfirming">
+      @_confirmButtonText
+    </button>
+    @if (!string.IsNullOrEmpty(_statusMessage))
+    {
+      <div class="cf-status">@_statusMessage</div>
     }
-  </div>
+  }
 </div>
 
 @code {
@@ -121,6 +123,21 @@
   private string _confirmButtonText => _isConfirming ? "Confirming..." : "I have sent the payment";
 
   private CryptoOption SelectedOption => _options[_selectedAsset].First(o => o.Network == _selectedNetwork);
+
+  private async Task CopyToClipboard(string address)
+  {
+    try
+    {
+      await JS.InvokeVoidAsync("navigator.clipboard.writeText", address);
+      _statusMessage = "Wallet address copied";
+    }
+    catch
+    {
+      _statusMessage = "Copy this address manually if your browser blocks clipboard access.";
+    }
+
+    StateHasChanged();
+  }
 
   protected override async Task OnInitializedAsync()
   {

--- a/src/CoachFitAI.Web/Pages/Shared/Components/CryptoStablecoinPayment.razor
+++ b/src/CoachFitAI.Web/Pages/Shared/Components/CryptoStablecoinPayment.razor
@@ -1,0 +1,199 @@
+@using System.Globalization
+@using System.Linq
+@inject IPaymentService Payments
+@inject AppState State
+
+<div class="card shadow-sm crypto-stablecoin border-0">
+  <div class="card-body">
+    <h5 class="card-title">Pay with USDT or USDC</h5>
+    <p class="text-muted small mb-4">
+      Send the exact amount to the wallet address below using one of the supported networks.
+      Once the transfer is complete, confirm to finalize your order.
+    </p>
+
+    @if (_isLoading)
+    {
+      <div class="text-center py-4">
+        <div class="spinner-border text-primary" role="status">
+          <span class="visually-hidden">Loading...</span>
+        </div>
+      </div>
+    }
+    else if (!string.IsNullOrEmpty(_errorMessage))
+    {
+      <div class="alert alert-danger" role="alert">
+        @_errorMessage
+      </div>
+      <button class="btn btn-outline-primary w-100" @onclick="ReloadOrder">Retry</button>
+    }
+    else if (_isCompleted)
+    {
+      <div class="alert alert-success" role="alert">
+        Payment confirmed! You will be redirected shortly.
+      </div>
+    }
+    else if (_order is not null)
+    {
+      <div class="mb-3">
+        <label class="form-label">Choose a stablecoin</label>
+        <div class="btn-group w-100" role="group">
+          @foreach (var asset in _options.Keys)
+          {
+            <button type="button"
+                    class="btn btn-outline-primary @((asset == _selectedAsset ? "active" : string.Empty))"
+                    @onclick="() => SelectAsset(asset)">
+              @asset
+            </button>
+          }
+        </div>
+      </div>
+
+      <div class="mb-3">
+        <label class="form-label">Select network</label>
+        <select class="form-select" @bind="_selectedNetwork">
+          @foreach (var option in _options[_selectedAsset])
+          {
+            <option value="@option.Network">@option.Network</option>
+          }
+        </select>
+        <div class="form-text">Only send @AmountUsd.ToString("0.00", CultureInfo.InvariantCulture) @_selectedAsset on this network.</div>
+      </div>
+
+      <div class="mb-3">
+        <label class="form-label">Amount</label>
+        <div class="fs-5 fw-semibold">
+          @AmountUsd.ToString("0.00", CultureInfo.InvariantCulture) @_selectedAsset
+        </div>
+        <div class="form-text">Stablecoins track the US Dollar 1:1, so @AmountUsd.ToString("0.00", CultureInfo.InvariantCulture) USD = @AmountUsd.ToString("0.00", CultureInfo.InvariantCulture) @_selectedAsset.</div>
+      </div>
+
+      <div class="mb-3">
+        <label class="form-label">Wallet address</label>
+        <div class="border rounded px-3 py-2 bg-light user-select-all">
+          @SelectedOption.Address
+        </div>
+        @if (!string.IsNullOrWhiteSpace(SelectedOption.Note))
+        {
+          <div class="form-text">@SelectedOption.Note</div>
+        }
+      </div>
+
+      <button class="btn btn-success w-100" @onclick="ConfirmPayment" disabled="@_isConfirming">
+        @_confirmButtonText
+      </button>
+      @if (!string.IsNullOrEmpty(_statusMessage))
+      {
+        <div class="form-text text-muted text-center mt-2">@_statusMessage</div>
+      }
+    }
+  </div>
+</div>
+
+@code {
+  [Parameter] public decimal AmountUsd { get; set; }
+  [Parameter] public EventCallback OnPaymentCompleted { get; set; }
+
+  private readonly Dictionary<string, List<CryptoOption>> _options = new()
+  {
+    ["USDT"] = new()
+    {
+      new CryptoOption("Ethereum (ERC-20)", "0x1234....USDT", "Network fee may be higher on Ethereum."),
+      new CryptoOption("Polygon (USDT)", "0x9876....USDT", "Transfers usually confirm within a minute."),
+      new CryptoOption("Tron (TRC-20)", "TJ2exampleaddressForUSDT", "Double-check the network before sending.")
+    },
+    ["USDC"] = new()
+    {
+      new CryptoOption("Ethereum (ERC-20)", "0x1234....USDC", "Network fee may be higher on Ethereum."),
+      new CryptoOption("Polygon (USDC)", "0x9876....USDC", "Supports fast confirmations with low fees."),
+      new CryptoOption("Solana (SPL)", "5GexampleSolUSDCAddress", "Use a Solana-compatible wallet when selecting SPL.")
+    }
+  };
+
+  private OrderDto? _order;
+  private string _selectedAsset = "USDT";
+  private string _selectedNetwork = string.Empty;
+  private bool _isLoading = true;
+  private bool _isConfirming;
+  private bool _isCompleted;
+  private string? _errorMessage;
+  private string? _statusMessage;
+
+  private string _confirmButtonText => _isConfirming ? "Confirming..." : "I have sent the payment";
+
+  private CryptoOption SelectedOption => _options[_selectedAsset].First(o => o.Network == _selectedNetwork);
+
+  protected override async Task OnInitializedAsync()
+  {
+    await LoadOrderAsync();
+  }
+
+  private async Task LoadOrderAsync()
+  {
+    _isLoading = true;
+    _errorMessage = null;
+
+    try
+    {
+      _order = State.Order;
+      if (_order is null || _order.Amount != AmountUsd)
+      {
+        _order = await Payments.StartCheckoutAsync(AmountUsd);
+        State.SetOrder(_order);
+      }
+
+      _selectedAsset = _options.Keys.First();
+      _selectedNetwork = _options[_selectedAsset].First().Network;
+    }
+    catch (Exception ex)
+    {
+      _errorMessage = $"Unable to prepare payment: {ex.Message}";
+    }
+    finally
+    {
+      _isLoading = false;
+    }
+  }
+
+  private void SelectAsset(string asset)
+  {
+    if (_selectedAsset == asset)
+    {
+      return;
+    }
+
+    _selectedAsset = asset;
+    _selectedNetwork = _options[_selectedAsset].First().Network;
+  }
+
+  private async Task ConfirmPayment()
+  {
+    if (_order is null || _isConfirming)
+    {
+      return;
+    }
+
+    _isConfirming = true;
+    _statusMessage = "Waiting for confirmation...";
+
+    var confirmed = await Payments.ConfirmPaymentAsync(_order.Id);
+    _isConfirming = false;
+
+    if (confirmed)
+    {
+      _isCompleted = true;
+      _statusMessage = "Payment confirmed";
+      await OnPaymentCompleted.InvokeAsync();
+    }
+    else
+    {
+      _statusMessage = "We could not confirm the payment yet. Please try again in a few seconds.";
+    }
+  }
+
+  private Task ReloadOrder()
+  {
+    return LoadOrderAsync();
+  }
+
+  private record CryptoOption(string Network, string Address, string? Note);
+}

--- a/src/CoachFitAI.Web/_Imports.razor
+++ b/src/CoachFitAI.Web/_Imports.razor
@@ -1,4 +1,4 @@
-﻿@using System.Net.Http
+@using System.Net.Http
 @using Microsoft.AspNetCore.Components
 @using Microsoft.AspNetCore.Components.Forms
 @using Microsoft.AspNetCore.Components.Routing
@@ -8,5 +8,6 @@
 
 @using CoachFitAI.Web
 @using CoachFitAI.Web.Pages.Shared
+@using CoachFitAI.Web.Pages.Shared.Components
 @using CoachFitAI.Web.State
 @using CoachFitAI.Web.Services

--- a/src/CoachFitAI.Web/wwwroot/css/base.css
+++ b/src/CoachFitAI.Web/wwwroot/css/base.css
@@ -98,8 +98,51 @@
 .cf-card {
     transition: transform .12s ease, box-shadow .12s ease;
   }
-  .cf-card:hover {
+.cf-card:hover {
     transform: translateY(-2px);
     box-shadow: 0 6px 20px rgba(0,0,0,.25);
   }
+
+  /* Checkout crypto payment */
+  .cf-payment-card{
+    margin-top:18px;
+    background:linear-gradient(180deg,#141d3c,#10172f);
+    border:1px solid var(--border);
+    border-radius:16px;
+    padding:24px;
+    color:var(--text);
+    box-shadow:0 12px 40px rgba(8,12,24,0.35);
+  }
+
+  .cf-payment-header{margin-bottom:20px}
+  .cf-payment-title{margin:0 0 6px;font-size:20px;font-weight:700;color:var(--text)}
+  .cf-payment-subtitle{margin:0;color:var(--muted);font-size:14px;line-height:1.6}
+
+  .cf-payment-loading{display:flex;flex-direction:column;align-items:center;gap:12px;padding:30px 0;color:var(--muted);font-weight:600}
+
+  .cf-spinner{width:36px;height:36px;border-radius:999px;border:3px solid rgba(96,165,250,.2);border-top-color:var(--brand);animation:cf-spin .8s linear infinite}
+
+  @keyframes cf-spin{to{transform:rotate(360deg)}}
+
+  .cf-alert{padding:12px 14px;border-radius:12px;border:1px solid transparent;font-weight:600;margin-bottom:16px}
+  .cf-alert-error{border-color:rgba(248,113,113,.45);background:rgba(248,113,113,.14);color:#fecaca}
+  .cf-alert-success{border-color:rgba(52,211,153,.4);background:rgba(16,185,129,.18);color:#bbf7d0}
+
+  .cf-field{margin-bottom:18px}
+
+  .cf-pill-group{display:flex;gap:10px}
+  .cf-pill{flex:1;padding:10px 12px;border-radius:12px;border:1px solid var(--border);background:#0f1833;color:var(--muted);font-weight:600;cursor:pointer;transition:all .16s ease}
+  .cf-pill:hover{border-color:#2a3a64;color:var(--text)}
+  .cf-pill.active{border-color:var(--brand);background:linear-gradient(180deg,rgba(94,234,212,.2),rgba(14,116,144,.15));color:var(--text);box-shadow:0 0 0 1px rgba(94,234,212,.2)}
+
+  .cf-help{display:block;margin-top:6px;font-size:13px;color:var(--muted)}
+
+  .cf-amount-display{display:flex;align-items:baseline;gap:8px;font-weight:700}
+  .cf-amount-value{font-size:24px}
+  .cf-amount-asset{font-size:16px;color:var(--muted)}
+
+  .cf-wallet{padding:12px 14px;border-radius:12px;border:1px dashed rgba(94,234,212,.4);background:#0f1833;font-family:"SFMono-Regular",Consolas,"Liberation Mono",Menlo,monospace;font-size:14px;cursor:pointer;transition:border-color .16s ease, background .16s ease}
+  .cf-wallet:hover{border-color:var(--brand);background:rgba(14,116,144,.16)}
+
+  .cf-status{margin-top:12px;text-align:center;font-size:13px;color:var(--muted)}
   


### PR DESCRIPTION
## Summary
- add a reusable crypto stablecoin payment component with support for USDT and USDC instructions
- update checkout to render the new component and wire payment confirmation navigation
- expose the shared components namespace for easy use across pages

## Testing
- dotnet build *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68dc4a6c1828832e97f0adfff3de7a4b