### PR TITLE
Add crypto checkout component with webhook simulation

### DIFF
--- a/src/CoachFitAI.Web/Pages/Checkout.razor
+++ b/src/CoachFitAI.Web/Pages/Checkout.razor
@@ -17,7 +17,28 @@
       else
       {
         <p class="fs-5">Plan price: <b>$7</b></p>
-        <button class="btn btn-primary px-4 mt-3" @onclick="Pay">Pay (mock)</button>
+
+        @if (!string.IsNullOrEmpty(_error))
+        {
+          <div class="alert alert-danger" role="alert">@_error</div>
+        }
+
+        @if (_order is null)
+        {
+          <button class="btn btn-primary px-4 mt-3" disabled="@_isStarting" @onclick="StartPaymentAsync">
+            @if (_isStarting)
+            {
+              <span class="spinner-border spinner-border-sm me-2" role="status"></span>
+            }
+            Start USDT/USDC payment
+          </button>
+          <p class="text-muted small mt-3">You will receive wallet details and status updates after starting the checkout.</p>
+        }
+        else
+        {
+          <CryptoPaymentWidget Order="_order" OnStatusChanged="HandleOrderStatusAsync" />
+          <p class="text-muted small mt-3">Leave this tab open. We will redirect you automatically once the payment is confirmed.</p>
+        }
       }
 
     </div>
@@ -25,11 +46,47 @@
 </div>
 
 @code {
-  async Task Pay()
+  OrderDto? _order;
+  bool _isStarting;
+  string? _error;
+
+  protected override void OnInitialized()
   {
-    var order = await Payments.StartCheckoutAsync(7m);
-    State.SetOrder(order);
-    var ok = await Payments.ConfirmPaymentAsync(order.Id);
-    if (ok) Nav.NavigateTo("thank-you");
+    _order = State.Order;
+  }
+
+  async Task StartPaymentAsync()
+  {
+    if (_isStarting)
+    {
+      return;
+    }
+
+    _error = null;
+    _isStarting = true;
+
+    try
+    {
+      _order = await Payments.StartCheckoutAsync(7m);
+      State.SetOrder(_order);
+    }
+    catch
+    {
+      _error = "We couldn't start the crypto checkout. Please try again.";
+      _order = null;
+    }
+    finally
+    {
+      _isStarting = false;
+    }
+  }
+
+  async Task HandleOrderStatusAsync(OrderStatusUpdateDto update)
+  {
+    var ok = await Payments.ConfirmPaymentAsync(update.OrderId);
+    if (ok)
+    {
+      Nav.NavigateTo("thank-you");
+    }
   }
 }

--- a/src/CoachFitAI.Web/Pages/Shared/Components/CryptoPaymentWidget.razor
+++ b/src/CoachFitAI.Web/Pages/Shared/Components/CryptoPaymentWidget.razor
@@ -1,0 +1,190 @@
+@using System.Globalization
+@implements IAsyncDisposable
+@inject IPaymentService PaymentService
+@inject IJSRuntime JS
+
+@if (Order is null)
+{
+    <div class="alert alert-info">Payment session has not been started.</div>
+}
+else
+{
+    <div class="card shadow-sm text-start">
+        <div class="card-body">
+            <h5 class="card-title">Send stablecoin payment</h5>
+            <p class="card-text">
+                Send exactly <b>@Order.Amount.ToString("0.00") @Order.Currency</b> in USDT or USDC to one of the wallet addresses below.
+                The checkout will advance automatically after the payment is detected by the webhook listener.
+            </p>
+        </div>
+
+        <ul class="list-group list-group-flush">
+            @foreach (var wallet in Order.Wallets ?? Array.Empty<CryptoWalletDto>())
+            {
+                <li class="list-group-item">
+                    <div class="d-flex justify-content-between align-items-start">
+                        <div>
+                            <span class="badge bg-dark">@wallet.Symbol</span>
+                            <span class="ms-2 text-muted">@wallet.Network</span>
+                        </div>
+                        <button class="btn btn-sm btn-outline-secondary" @onclick="() => CopyAddress(wallet.Address)">
+                            Copy address
+                        </button>
+                    </div>
+                    <div class="mt-2">
+                        <code class="small user-select-all">@wallet.Address</code>
+                    </div>
+                    @if (!string.IsNullOrWhiteSpace(wallet.Memo))
+                    {
+                        <div class="mt-2 small">
+                            Memo / Tag: <code class="user-select-all">@wallet.Memo</code>
+                        </div>
+                    }
+                    @if (!string.IsNullOrWhiteSpace(wallet.Note))
+                    {
+                        <div class="mt-2 small text-muted">@wallet.Note</div>
+                    }
+                </li>
+            }
+        </ul>
+
+        <div class="card-body">
+            <div class="d-flex align-items-center">
+                <span class="me-2 fw-semibold">Status:</span>
+                <span class="@StatusBadgeClass">@StatusText</span>
+            </div>
+            @if (!string.IsNullOrEmpty(_statusMessage))
+            {
+                <div class="small text-muted mt-2">@_statusMessage</div>
+            }
+            @if (!string.IsNullOrEmpty(_transactionHash))
+            {
+                <div class="small text-muted mt-2">
+                    Tx hash: <code class="user-select-all">@_transactionHash</code>
+                </div>
+            }
+        </div>
+    </div>
+}
+
+@code {
+    [Parameter] public OrderDto? Order { get; set; }
+    [Parameter] public EventCallback<OrderStatusUpdateDto> OnStatusChanged { get; set; }
+
+    private Guid? _listeningOrderId;
+    private CancellationTokenSource? _cts;
+    private Task? _listenTask;
+    private string? _statusMessage;
+    private string? _transactionHash;
+
+    private string StatusText => string.IsNullOrWhiteSpace(Order?.Status)
+        ? "Pending"
+        : CultureInfo.CurrentCulture.TextInfo.ToTitleCase(Order!.Status);
+
+    private string StatusBadgeClass => Order?.Status?.ToLowerInvariant() switch
+    {
+        "confirmed" or "fulfilled" => "badge bg-success",
+        "pending" => "badge bg-warning text-dark",
+        "failed" => "badge bg-danger",
+        _ => "badge bg-secondary"
+    };
+
+    protected override async Task OnParametersSetAsync()
+    {
+        if (Order?.Id == _listeningOrderId)
+        {
+            return;
+        }
+
+        await StopListeningAsync();
+
+        if (Order is null)
+        {
+            _statusMessage = null;
+            _transactionHash = null;
+            return;
+        }
+
+        _listeningOrderId = Order.Id;
+        _statusMessage = "Awaiting your transfer. Leave this page open while we monitor the blockchain.";
+        _transactionHash = null;
+
+        _cts = new CancellationTokenSource();
+        _listenTask = PaymentService.SubscribeToWebhookAsync(Order.Id, HandleWebhookAsync, _cts.Token);
+    }
+
+    private async Task HandleWebhookAsync(OrderStatusUpdateDto update)
+    {
+        if (Order is null || update.OrderId != Order.Id)
+        {
+            return;
+        }
+
+        Order.Status = update.Status;
+
+        if (!string.IsNullOrEmpty(update.Message))
+        {
+            _statusMessage = update.Message;
+        }
+
+        if (!string.IsNullOrEmpty(update.TransactionHash))
+        {
+            _transactionHash = update.TransactionHash;
+        }
+
+        await InvokeAsync(StateHasChanged);
+
+        if (string.Equals(update.Status, "confirmed", StringComparison.OrdinalIgnoreCase))
+        {
+            await OnStatusChanged.InvokeAsync(update);
+        }
+    }
+
+    private async Task StopListeningAsync()
+    {
+        if (_cts is null)
+        {
+            return;
+        }
+
+        _cts.Cancel();
+
+        if (_listenTask is not null)
+        {
+            try
+            {
+                await _listenTask;
+            }
+            catch (OperationCanceledException)
+            {
+            }
+            catch (TaskCanceledException)
+            {
+            }
+        }
+
+        _cts.Dispose();
+        _cts = null;
+        _listenTask = null;
+        _listeningOrderId = null;
+    }
+
+    private async Task CopyAddress(string address)
+    {
+        if (string.IsNullOrWhiteSpace(address))
+        {
+            return;
+        }
+
+        await JS.InvokeVoidAsync("navigator.clipboard.writeText", address);
+
+        var tail = address.Length > 6 ? address[^6..] : address;
+        _statusMessage = $"Address copied (…{tail}).";
+        await InvokeAsync(StateHasChanged);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await StopListeningAsync();
+    }
+}

--- a/src/CoachFitAI.Web/Services/IPaymentService.cs
+++ b/src/CoachFitAI.Web/Services/IPaymentService.cs
@@ -1,7 +1,12 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
 using CoachFitAI.Web.State;
+
 namespace CoachFitAI.Web.Services;
 public interface IPaymentService
 {
     Task<OrderDto> StartCheckoutAsync(decimal amountUsd);
     Task<bool> ConfirmPaymentAsync(Guid orderId);
+    Task SubscribeToWebhookAsync(Guid orderId, Func<OrderStatusUpdateDto, Task> onUpdate, CancellationToken cancellationToken = default);
 }

--- a/src/CoachFitAI.Web/Services/Mock/MockPaymentService.cs
+++ b/src/CoachFitAI.Web/Services/Mock/MockPaymentService.cs
@@ -1,17 +1,99 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
 using CoachFitAI.Web.State;
+
 namespace CoachFitAI.Web.Services.Mock;
 
 public class MockPaymentService : IPaymentService
 {
+    private readonly ConcurrentDictionary<Guid, OrderDto> _orders = new();
+
     public Task<OrderDto> StartCheckoutAsync(decimal amountUsd)
-        => Task.FromResult(new OrderDto
+    {
+        var order = new OrderDto
         {
             Id = Guid.NewGuid(),
             Amount = amountUsd,
             Currency = "USD",
-            Provider = "mock",
-            Status = "pending"
-        });
+            Provider = "mock-crypto",
+            Status = "pending",
+            Wallets = new List<CryptoWalletDto>
+            {
+                new()
+                {
+                    Symbol = "USDT",
+                    Network = "TRON (TRC20)",
+                    Address = "TK1MockAddress1234567890",
+                    Note = "Stablecoin deposit address"
+                },
+                new()
+                {
+                    Symbol = "USDC",
+                    Network = "Ethereum (ERC20)",
+                    Address = "0xMockAddress1234567890ABCDEF",
+                    Note = "Gas fees apply on Ethereum"
+                }
+            }
+        };
 
-    public Task<bool> ConfirmPaymentAsync(Guid orderId) => Task.FromResult(true);
+        _orders[order.Id] = order;
+        return Task.FromResult(order);
+    }
+
+    public Task<bool> ConfirmPaymentAsync(Guid orderId)
+    {
+        if (_orders.TryGetValue(orderId, out var order) &&
+            string.Equals(order.Status, "confirmed", StringComparison.OrdinalIgnoreCase))
+        {
+            order.Status = "fulfilled";
+            return Task.FromResult(true);
+        }
+
+        return Task.FromResult(false);
+    }
+
+    public Task SubscribeToWebhookAsync(Guid orderId, Func<OrderStatusUpdateDto, Task> onUpdate, CancellationToken cancellationToken = default)
+    {
+        if (!_orders.TryGetValue(orderId, out var order))
+        {
+            return Task.CompletedTask;
+        }
+
+        return Task.Run(async () =>
+        {
+            await onUpdate(new OrderStatusUpdateDto
+            {
+                OrderId = order.Id,
+                Status = order.Status,
+                Message = "Waiting for stablecoin transfer."
+            });
+
+            try
+            {
+                await Task.Delay(TimeSpan.FromSeconds(6), cancellationToken);
+            }
+            catch (TaskCanceledException)
+            {
+                return;
+            }
+
+            if (cancellationToken.IsCancellationRequested)
+            {
+                return;
+            }
+
+            order.Status = "confirmed";
+
+            await onUpdate(new OrderStatusUpdateDto
+            {
+                OrderId = order.Id,
+                Status = order.Status,
+                Message = "Mock webhook: payment detected and confirmed.",
+                TransactionHash = Guid.NewGuid().ToString("N")
+            });
+        }, cancellationToken);
+    }
 }

--- a/src/CoachFitAI.Web/State/Models.cs
+++ b/src/CoachFitAI.Web/State/Models.cs
@@ -24,6 +24,24 @@ public class OrderDto
     public string Currency { get; set; } = string.Empty;
     public string Provider { get; set; } = string.Empty;
     public string Status { get; set; } = string.Empty;
+    public IReadOnlyList<CryptoWalletDto> Wallets { get; set; } = Array.Empty<CryptoWalletDto>();
+}
+
+public class CryptoWalletDto
+{
+    public string Symbol { get; set; } = string.Empty;
+    public string Network { get; set; } = string.Empty;
+    public string Address { get; set; } = string.Empty;
+    public string? Memo { get; set; }
+    public string? Note { get; set; }
+}
+
+public class OrderStatusUpdateDto
+{
+    public Guid OrderId { get; set; }
+    public string Status { get; set; } = string.Empty;
+    public string? Message { get; set; }
+    public string? TransactionHash { get; set; }
 }
 
 public class IngredientDto

--- a/src/CoachFitAI.Web/_Imports.razor
+++ b/src/CoachFitAI.Web/_Imports.razor
@@ -8,5 +8,6 @@
 
 @using CoachFitAI.Web
 @using CoachFitAI.Web.Pages.Shared
+@using CoachFitAI.Web.Pages.Shared.Components
 @using CoachFitAI.Web.State
 @using CoachFitAI.Web.Services


### PR DESCRIPTION
## Summary
- add a checkout widget that exposes USDT/USDC wallet details and listens for webhook updates
- extend payment models and service contracts to surface wallet information and webhook notifications
- update the mock payment service to simulate webhook-driven confirmations for testing

## Testing
- dotnet build *(fails: `dotnet` not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dc557a3cac832eb3ae5fabb4379124